### PR TITLE
Feat/image page

### DIFF
--- a/app/api/generate-image/route.ts
+++ b/app/api/generate-image/route.ts
@@ -112,7 +112,6 @@ export async function POST(request: NextRequest) {
     // Refactored pipeline
     const imageData = await generateImage(prompt);
     const filePath = await uploadImage(supabase, user.id, imageData);
-    await new Promise((res) => setTimeout(res, 1000));
     const imageUrl = await createSignedUrl(supabase, filePath);
 
     return NextResponse.json({ success: true, imageUrl });

--- a/app/api/generate-image/route.ts
+++ b/app/api/generate-image/route.ts
@@ -1,69 +1,130 @@
 import { NextRequest, NextResponse } from "next/server";
 import { GoogleGenAI, Modality } from "@google/genai";
+import { createClient } from "@/utils/supabase/server";
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { Buffer } from "buffer";
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY;
+
+/**
+ * Generates an image from a text prompt using Google's Gemini model.
+ * @param prompt The text prompt for image generation.
+ * @returns The base64 encoded image data.
+ */
+async function generateImage(prompt: string): Promise<string> {
+  if (!GEMINI_API_KEY) {
+    throw new Error("GEMINI_API_KEY is not configured on the server.");
+  }
+  const ai = new GoogleGenAI({ apiKey: GEMINI_API_KEY });
+
+  try {
+    const response = await ai.models.generateContent({
+      model: "gemini-2.0-flash-preview-image-generation",
+      contents: prompt,
+      config: { responseModalities: [Modality.TEXT, Modality.IMAGE] },
+    });
+
+    const imagePart = response.candidates?.[0]?.content?.parts?.find(
+      (p) => p.inlineData
+    );
+
+    if (!imagePart?.inlineData?.data) {
+      throw new Error(
+        "Failed to extract image data from the generation response."
+      );
+    }
+    return imagePart.inlineData.data;
+  } catch (error) {
+    console.error("Error during image generation:", error);
+    throw new Error("Failed to generate image.");
+  }
+}
+
+/**
+ * Uploads a base64 encoded image to Supabase Storage.
+ * @param supabase The Supabase client instance.
+ * @param userId The ID of the user uploading the image.
+ * @param imageDataB64 The base64 encoded image data.
+ * @returns The file path of the uploaded image.
+ */
+async function uploadImage(
+  supabase: SupabaseClient,
+  userId: string,
+  imageDataB64: string
+): Promise<string> {
+  const filePath = `private/${userId}/${Date.now()}.png`;
+  const { error } = await supabase.storage
+    .from("generated-images")
+    .upload(filePath, Buffer.from(imageDataB64, "base64"), {
+      contentType: "image/png",
+    });
+
+  if (error) {
+    console.error("Supabase upload error:", error);
+    throw new Error("Failed to upload image to storage.");
+  }
+  return filePath;
+}
+
+/**
+ * Creates a signed URL for a file in Supabase Storage.
+ * @param supabase The Supabase client instance.
+ * @param filePath The path of the file in the storage bucket.
+ * @returns The signed URL for private access.
+ */
+async function createSignedUrl(
+  supabase: SupabaseClient,
+  filePath: string
+): Promise<string> {
+  const { data, error } = await supabase.storage
+    .from("generated-images")
+    .createSignedUrl(filePath, 3600); // 1 hour expiry
+
+  if (error || !data) {
+    console.error("Signed URL creation error:", error);
+    throw new Error("Failed to create a signed URL for the image.");
+  }
+  return data.signedUrl;
+}
 
 export async function POST(request: NextRequest) {
   try {
-    const { prompt } = await request.json();
-    if (!prompt) {
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+
+    if (!user) {
       return NextResponse.json(
-        { error: "prompt가 비어 있습니다." },
+        { success: false, error: "Unauthorized" },
+        { status: 401 }
+      );
+    }
+
+    const { prompt } = await request.json();
+    if (!prompt || typeof prompt !== "string") {
+      return NextResponse.json(
+        { success: false, error: "A valid text prompt is required." },
         { status: 400 }
       );
     }
 
-    const ai = new GoogleGenAI({ apiKey: process.env.GEMINI_API_KEY! });
+    // Refactored pipeline
+    const imageData = await generateImage(prompt);
+    const filePath = await uploadImage(supabase, user.id, imageData);
+    await new Promise((res) => setTimeout(res, 1000));
+    const imageUrl = await createSignedUrl(supabase, filePath);
 
-    // 3) 이미지 생성 호출
-    const response = await ai.models.generateContent({
-      model: "gemini-2.0-flash-preview-image-generation",
-      contents: prompt,
-      config: {
-        responseModalities: [Modality.TEXT, Modality.IMAGE],
-      },
-    });
-
-    if (!response || !response.candidates || response.candidates.length === 0) {
-      return NextResponse.json(
-        { error: "이미지 생성에 실패했습니다." },
-        { status: 500 }
-      );
-    }
-
-    if (
-      !response.candidates[0].content ||
-      !response.candidates[0].content.parts
-    ) {
-      return NextResponse.json(
-        { error: "이미지 생성에 실패했습니다. content가 비정상일수 있나?" },
-        { status: 500 }
-      );
-    }
-
-    const parts = response.candidates[0].content.parts;
-    // 텍스트 파트는 무시하고, 이미지 파트 하나만 가정
-    const imagePart = parts.find((p) => p.inlineData);
-    if (!imagePart || !imagePart.inlineData) {
-      return NextResponse.json(
-        { error: "이미지 생성에 실패했습니다. imagePart에 데이터가 없음?" },
-        { status: 500 }
-      );
-    }
-
-    const base64Data: string = imagePart.inlineData.data!; // 여기에 데이터에 오류가 있을수 있는지 확인하기. 🚨
+    return NextResponse.json({ success: true, imageUrl });
+  } catch (error) {
+    console.error("[generate-image POST Error]", error);
     return NextResponse.json(
-      { imageBase64: base64Data },
       {
-        status: 200,
-        headers: {
-          "Content-Type": "application/json",
-        },
-      }
+        success: false,
+        error:
+          error instanceof Error ? error.message : "An unknown error occurred.",
+      },
+      { status: 500 }
     );
-  } catch (err: unknown) {
-    console.error("[generate-image Error]", err);
-    if (err instanceof Error) {
-      return NextResponse.json({ error: err.message }, { status: 500 });
-    }
-    return NextResponse.json({ error: "서버 에러" }, { status: 500 });
   }
 }

--- a/app/gen-image/page.tsx
+++ b/app/gen-image/page.tsx
@@ -6,7 +6,7 @@ import ImageViewer from "./ImageViewer";
 
 function GenImageHome() {
   const [imageSrc, setImageSrc] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false); // 추가
+  const [isLoading, setIsLoading] = useState(false);
 
   const handleSendMessage = async (message: string) => {
     setIsLoading(true);
@@ -20,7 +20,7 @@ function GenImageHome() {
       if (!res.ok) {
         throw new Error(data.error || "이미지 생성 실패");
       }
-      setImageSrc(`data:image/png;base64,${data.imageBase64}`);
+      setImageSrc(data.imageUrl);
     } catch (e: unknown) {
       if (e instanceof Error) {
         alert(e.message);


### PR DESCRIPTION
- 이미지 생성후 클라이언트 전달하는 과정 변경 
   - 기존 : 구글에서 이미지 생성 후 클라이언트에 base64이미지 형식 그대로 리턴
   - 변경 : 구글 이미지 ->  슈퍼베이스 스토리지 -> [singedUrl]-> 클라이언트 
- generateImage, uploadImage, createSignedUrl 로 함수 분리
- 간단한 응답 처리
