### PR TITLE
feat: add global Header layout and fix viewport height

### DIFF
--- a/app/gen-image/page.tsx
+++ b/app/gen-image/page.tsx
@@ -72,7 +72,7 @@ function GenImageHome() {
   }, []);
 
   return (
-    <div className='flex h-screen bg-gray-100'>
+    <div className='flex h-[calc(100vh-4rem)] bg-gray-100'>
       <div className='flex-1 flex flex-col p-4'>
         <div className='flex-1 flex items-center justify-center mb-8'>
           <div className='w-full max-w-2xl'>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
+import Header from "./components/layout/Header";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -46,7 +47,10 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        {children}
+        <Header />
+        <main className="pt-16">
+          {children}
+        </main>
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,10 +1,8 @@
-import Header from "./components/layout/Header";
 import MaterialSection from "./components/materials/MaterialSection";
 
 export default function Home() {
   return (
     <>
-      <Header />
       <MaterialSection />
       <section className='flex flex-col items-center justify-center h-screen bg-gray-100'>
         <h1 className='text-4xl font-bold mb-4'>


### PR DESCRIPTION
## Summary
- Add Header component to root layout for all pages
- Remove duplicate Header from home page  
- Fix gen-image page height to account for fixed header

## Changes
- Modified `app/layout.tsx` to include Header component globally
- Updated `app/page.tsx` to remove duplicate Header import
- Changed `app/gen-image/page.tsx` height from `h-screen` to `h-[calc(100vh-4rem)]` to account for fixed header

## Test plan
- [x] Verify Header appears on all pages
- [x] Confirm no duplicate headers on home page
- [x] Check gen-image page fits properly within viewport
- [x] Test responsive behavior across different screen sizes

🤖 Generated with [Claude Code](https://claude.ai/code)